### PR TITLE
Allow requests/reverse proxy to reside at a non-localhost IP address

### DIFF
--- a/ocs/__main__.py
+++ b/ocs/__main__.py
@@ -12,7 +12,7 @@ from ocs.server import server
 def main():
     """Run the server"""
     
-    httpd = ThreadingHTTPServer(('localhost', args.port), server)
+    httpd = ThreadingHTTPServer(('', args.port), server)
     logging.info('Starting server')
     httpd.serve_forever()
 


### PR DESCRIPTION
I was unable to set up a reverse proxy given that it didn't reference the app at `localhost`, I believe this should fix it.