### PR TITLE
Use Debian Sid for up-to-date packages instead of Bullseye stable repos

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,5 +6,6 @@ COPY . .
 
 RUN apt-get update -y
 RUN apt-get install -y ghc python3 python-is-python3 python3-requests nodejs golang wget julia openjdk-17-jdk lua5.4 php ruby rustc mono-mcs
+RUN apt-get clean
 
 CMD [ "python3", "-m", "ocs", "--verbose" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,6 @@ WORKDIR /usr/src/app
 COPY . .
 
 RUN apt-get update -y
-RUN apt-get install -y ghc python3 python-is-python3 python3-pip nodejs golang wget julia openjdk-17-jdk lua5.4 php ruby rustc mono-mcs
-RUN pip install --no-cache-dir requests
+RUN apt-get install -y ghc python3 python-is-python3 python3-requests nodejs golang wget julia openjdk-17-jdk lua5.4 php ruby rustc mono-mcs
 
 CMD [ "python3", "-m", "ocs", "--verbose" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,8 @@ WORKDIR /usr/src/app
 
 COPY . .
 
-RUN apt update -y
-RUN apt install -y ghc python3 python-is-python3 python3-pip nodejs golang wget julia openjdk-17-jdk lua5.4 php ruby rustc mono-mcs
+RUN apt-get update -y
+RUN apt-get install -y ghc python3 python-is-python3 python3-pip nodejs golang wget julia openjdk-17-jdk lua5.4 php ruby rustc mono-mcs
 RUN pip install --no-cache-dir requests
 
 CMD [ "python3", "-m", "ocs", "--verbose" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:sid-slim
+FROM docker.io/debian:sid-slim
 
 WORKDIR /usr/src/app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM debian:11-slim
+FROM debian:sid-slim
 
 WORKDIR /usr/src/app
 
 COPY . .
 
 RUN apt update -y
-RUN apt install -y ghc python3 python-is-python3 python3-pip nodejs golang wget julia openjdk-11-jdk lua5.3 php ruby rustc mono-mcs
+RUN apt install -y ghc python3 python-is-python3 python3-pip nodejs golang wget julia openjdk-17-jdk lua5.4 php ruby rustc mono-mcs
 RUN pip install --no-cache-dir requests
 
 CMD [ "python3", "-m", "ocs", "--verbose" ]


### PR DESCRIPTION
Based on comments from @Ta180m regarding more up-to-date compilers and runtimes.